### PR TITLE
Schema references

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ resource "schemaregistry_schema" "with_reference" {
   subject = "with_reference_subject"
   schema = "[\"akc.test.event\", \"akc.test.other_event\"]"
 
-  references {
+  reference {
     name = "akc.test.event"
     subject = schemaregistry_schema.referenced_event.subject
     // version will always be upgraded with the referenced event schema version  
     version = schemaregistry_schema.referenced_event.version
   }
 
-  references {
+  reference {
     name = "akc.test.other_event"
     subject = schemaregistry_schema.user_added.subject
     // version will always be upgraded with the referenced event schema version  

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     schemaregistry = {
-      version = "0.4"
+      version = "0.6"
       source  = "github.com/arkiaconsulting/schemaregistry"
     }
   }
@@ -16,8 +16,19 @@ resource "schemaregistry_schema" "user_added" {
   schema  = file("./userAdded.avsc")
 }
 
+resource "schemaregistry_schema" "with_reference" {
+  subject = "with-reference"
+  schema = "[\"akc.test.userAdded\"]"
+
+  references {
+    name = "akc.test.userAdded"
+    subject = schemaregistry_schema.user_added.subject
+    version = schemaregistry_schema.user_added.version
+  }
+}
+
 data "schemaregistry_schema" "main" {
-  subject = schemaregistry_schema.user_added.subject
+  subject = schemaregistry_schema.with_reference.subject
 }
 
 output "schema_id" {
@@ -34,4 +45,8 @@ output "schema_string" {
 
 output "schema_schema_id" {
   value = data.schemaregistry_schema.main.schema_id
+}
+
+output "schema_references" {
+  value = data.schemaregistry_schema.main.references
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -20,7 +20,7 @@ resource "schemaregistry_schema" "with_reference" {
   subject = "with-reference"
   schema = "[\"akc.test.userAdded\"]"
 
-  references {
+  reference {
     name = "akc.test.userAdded"
     subject = schemaregistry_schema.user_added.subject
     version = schemaregistry_schema.user_added.version

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.16
 require (
 	github.com/hashicorp/go-uuid v1.0.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
-	github.com/riferrei/srclient v0.3.0
+	github.com/riferrei/srclient v0.3.1
 )

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/riferrei/srclient v0.3.0 h1:sNSz2P4ts0fuXr5/nNyD0lCdtF+AbN8Vq77CJhQriAg=
-github.com/riferrei/srclient v0.3.0/go.mod h1:SmCz0lrYQ1pLqXlYq0yPnRccHLGh+llDA0i6hecPeW8=
+github.com/riferrei/srclient v0.3.1 h1:AJ+wStokSOZgj0a8f/pIrEYGwkIRdjIhn5VU2sNfBzQ=
+github.com/riferrei/srclient v0.3.1/go.mod h1:SmCz0lrYQ1pLqXlYq0yPnRccHLGh+llDA0i6hecPeW8=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=

--- a/schemaregistry/data_source_schema.go
+++ b/schemaregistry/data_source_schema.go
@@ -32,6 +32,30 @@ func dataSourceSchema() *schema.Resource {
 				Computed:    true,
 				Description: "The schema string",
 			},
+			"references": {
+				Type:        schema.TypeList,
+				Computed: 	 true,
+				Description: "The referenced schema names list",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The referenced schema name",
+						},
+						"subject": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The subject related to the schema",
+						},
+						"version": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The version of the schema",
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -53,7 +77,28 @@ func dataSourceSubjectRead(ctx context.Context, d *schema.ResourceData, m interf
 	d.Set("schema_id", schema.ID())
 	d.Set("version", schema.Version())
 
+	if err = d.Set("references", FromRegistryReferences(schema.References())); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(formatSchemaVersionID(subject))
 
 	return diags
+}
+
+func FromRegistryReferences(references []srclient.Reference) []interface{} {
+	if len(references) == 0 {
+		return make([]interface{}, 0)
+	}
+
+	refs := make([]interface{}, 0, len(references))
+	for _, reference := range references {
+		refs = append(refs, map[string]interface{}{
+			"name": reference.Name,
+			"subject": reference.Subject,
+			"version": reference.Version,
+		})
+	}
+
+	return refs
 }

--- a/schemaregistry/data_source_schema.go
+++ b/schemaregistry/data_source_schema.go
@@ -85,20 +85,3 @@ func dataSourceSubjectRead(ctx context.Context, d *schema.ResourceData, m interf
 
 	return diags
 }
-
-func FromRegistryReferences(references []srclient.Reference) []interface{} {
-	if len(references) == 0 {
-		return make([]interface{}, 0)
-	}
-
-	refs := make([]interface{}, 0, len(references))
-	for _, reference := range references {
-		refs = append(refs, map[string]interface{}{
-			"name": reference.Name,
-			"subject": reference.Subject,
-			"version": reference.Version,
-		})
-	}
-
-	return refs
-}

--- a/schemaregistry/data_source_schema_test.go
+++ b/schemaregistry/data_source_schema_test.go
@@ -2,6 +2,9 @@ package schemaregistry
 
 import (
 	"fmt"
+	"github.com/riferrei/srclient"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -28,6 +31,77 @@ func TestAccDataSourceSchema_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.schemaregistry_schema.test", "version", "1"),
 					resource.TestCheckResourceAttr("data.schemaregistry_schema.test", "schema", strings.Replace(fixtureAvro1, "\\", "", -1)),
 					resource.TestCheckResourceAttrSet("data.schemaregistry_schema.test", "schema_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceSchemaReferences_basic(t *testing.T) {
+	// GIVEN
+	url, found := os.LookupEnv("SCHEMA_REGISTRY_URL")
+	if !found {
+		t.Fatalf("SCHEMA_REGISTRY_URL must be set for acceptance tests")
+	}
+	username := os.Getenv("SCHEMA_REGISTRY_USERNAME")
+	password := os.Getenv("SCHEMA_REGISTRY_PASSWORD")
+
+	client := srclient.CreateSchemaRegistryClient(url)
+	if (username != "") && (password != "") {
+		client.SetCredentials(username, password)
+	}
+
+	// AND
+	u, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	referencedSchemaSubject := fmt.Sprintf("referencedSub-%s", u)
+	referencedSchema := strings.Replace(fixtureAvro1, "\\", "", -1)
+
+	schemaWithReferenceSubject := fmt.Sprintf("sub-%s", u)
+	schemaWithReference := `["akc.test.userAdded"]`
+
+	references := []srclient.Reference{
+		{
+			Name:    "akc.test.userAdded",
+			Subject: referencedSchemaSubject,
+			Version: 1,
+		},
+	}
+
+	// AND
+	if _, err = client.CreateSchemaWithArbitrarySubject(referencedSchemaSubject, referencedSchema, srclient.Avro); err != nil {
+		t.Fatalf("could not create schema for subject: %s, err: %s", referencedSchema, err)
+	}
+
+	if _, err = client.CreateSchemaWithArbitrarySubject(schemaWithReferenceSubject, schemaWithReference, srclient.Avro, references...); err != nil {
+		t.Fatalf("could not create schema for subject: %s, err: %s", referencedSchemaSubject, err)
+	}
+
+	// WHEN / THEN
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					data "schemaregistry_schema" "schemaWithReference" {
+						subject = "%s"
+					}
+				`, schemaWithReferenceSubject),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.schemaregistry_schema.schemaWithReference", "id", schemaWithReferenceSubject),
+					resource.TestCheckResourceAttr("data.schemaregistry_schema.schemaWithReference", "subject", schemaWithReferenceSubject),
+					resource.TestCheckResourceAttrSet("data.schemaregistry_schema.schemaWithReference", "schema_id"),
+					resource.TestCheckResourceAttr("data.schemaregistry_schema.schemaWithReference", "version", "1"),
+					resource.TestCheckResourceAttr("data.schemaregistry_schema.schemaWithReference", "schema", schemaWithReference),
+
+					resource.TestCheckResourceAttr("data.schemaregistry_schema.schemaWithReference", "references.#", "1"),
+					resource.TestCheckResourceAttr("data.schemaregistry_schema.schemaWithReference", "references.0.name", references[0].Name),
+					resource.TestCheckResourceAttr("data.schemaregistry_schema.schemaWithReference", "references.0.subject", references[0].Subject),
+					resource.TestCheckResourceAttr("data.schemaregistry_schema.schemaWithReference", "references.0.version", strconv.Itoa(references[0].Version)),
 				),
 			},
 		},

--- a/schemaregistry/fixtures.go
+++ b/schemaregistry/fixtures.go
@@ -73,7 +73,7 @@ func fixtureResourceSchemaWithReferenceBuild(s schemaWithReferenceFixture) strin
 		schema = "{{.WithReferences.Schema}}"
 		{{range .References}}
 
-		references {
+		reference {
 			name = "{{.Name}}"
 			subject = {{.Subject}}
 			version = {{.Version}}

--- a/schemaregistry/fixtures.go
+++ b/schemaregistry/fixtures.go
@@ -1,6 +1,10 @@
 package schemaregistry
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+)
 
 const fixtureAvro1 = `{\"type\":\"record\",\"name\":\"userAdded\",\"namespace\":\"akc.test\",\"fields\":[{\"name\":\"firstName\",\"type\":\"string\"}]}`
 const fixtureAvro2 = `{\"type\":\"record\",\"name\":\"userAdded\",\"namespace\":\"akc.test\",\"fields\":[{\"name\":\"firstName\",\"type\":\"string\"},{\"name\":\"lastName\",\"type\":\"string\",\"default\":\"last\"}]}`
@@ -27,4 +31,60 @@ const fixtureImportSchema = `
 
 func fixtureDataSourceSchemaBuild(subject string, schema string) string {
 	return fmt.Sprintf("%s%s", fmt.Sprintf(fixtureCreateSchema, subject, schema), fixtureDataSourceSchema)
+}
+
+type SchemaResource struct {
+	ResourceName string
+	Subject      string
+	Schema       string
+}
+
+type SchemaWithReferences struct {
+	SchemaResource
+	ReferenceName string
+}
+
+type Reference struct {
+	Name    string
+	Subject string
+	Version string
+}
+
+type schemaWithReferenceFixture struct {
+	Type           string
+	Referenced     []SchemaResource
+	WithReferences SchemaResource
+	References     []Reference
+}
+
+func fixtureResourceSchemaWithReferenceBuild(s schemaWithReferenceFixture) string {
+	var buf bytes.Buffer
+
+	err := template.Must(template.New("SchemaWithReferenceFixture").Parse(`
+    {{range .Referenced}}
+	resource "schemaregistry_schema" "{{.ResourceName}}" {
+		subject = "{{.Subject}}"
+		schema = "{{.Schema}}"
+	}
+    {{end}}
+
+	resource "schemaregistry_schema" "{{.WithReferences.ResourceName}}" {
+		subject = "{{.WithReferences.Subject}}"
+		schema = "{{.WithReferences.Schema}}"
+		{{range .References}}
+
+		references {
+			name = "{{.Name}}"
+			subject = {{.Subject}}
+			version = {{.Version}}
+		}
+		{{end}}
+	}
+	`)).Execute(&buf, s)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return buf.String()
 }

--- a/schemaregistry/resource_schema.go
+++ b/schemaregistry/resource_schema.go
@@ -57,7 +57,7 @@ func resourceSchema() *schema.Resource {
 				Computed:    true,
 				Description: "The schema string",
 			},
-			"references": {
+			"reference": {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "The referenced schema list",
@@ -90,7 +90,7 @@ func schemaCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 
 	subject := d.Get("subject").(string)
 	schemaString := d.Get("schema").(string)
-	references := ToRegistryReferences(d.Get("references").([]interface{}))
+	references := ToRegistryReferences(d.Get("reference").([]interface{}))
 
 	client := meta.(*srclient.SchemaRegistryClient)
 
@@ -104,7 +104,7 @@ func schemaCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	d.Set("schema", schema.Schema())
 	d.Set("version", schema.Version())
 
-	if err = d.Set("references", FromRegistryReferences(schema.References())); err != nil {
+	if err = d.Set("reference", FromRegistryReferences(schema.References())); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -116,7 +116,7 @@ func schemaUpdate(ctx context.Context, d *schema.ResourceData, meta interface{})
 
 	subject := d.Get("subject").(string)
 	schemaString := d.Get("schema").(string)
-	references := ToRegistryReferences(d.Get("references").([]interface{}))
+	references := ToRegistryReferences(d.Get("reference").([]interface{}))
 
 	client := meta.(*srclient.SchemaRegistryClient)
 
@@ -132,7 +132,7 @@ func schemaUpdate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	d.Set("schema", schema.Schema())
 	d.Set("version", schema.Version())
 
-	if err = d.Set("references", FromRegistryReferences(schema.References())); err != nil {
+	if err = d.Set("reference", FromRegistryReferences(schema.References())); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -155,7 +155,7 @@ func schemaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	d.Set("subject", subject)
 	d.Set("version", schema.Version())
 
-	if err = d.Set("references", FromRegistryReferences(schema.References())); err != nil {
+	if err = d.Set("reference", FromRegistryReferences(schema.References())); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/schemaregistry/resource_schema_test.go
+++ b/schemaregistry/resource_schema_test.go
@@ -121,6 +121,391 @@ func TestAccResourceSchema_import(t *testing.T) {
 	})
 }
 
+func TestAccResourceSchemaReferences_basic(t *testing.T) {
+	u, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tt := []struct {
+		name    string
+		fixture schemaWithReferenceFixture
+		check   []resource.TestCheckFunc
+	}{
+		{
+			name: "single reference",
+			fixture: schemaWithReferenceFixture{
+				Referenced: []SchemaResource{
+					{
+						ResourceName: "referencedSchema",
+						Schema:       fixtureAvro1,
+						Subject:      fmt.Sprintf("referencedSub-%s", u),
+					},
+				},
+				WithReferences: SchemaResource{
+					ResourceName: "schemaWithReference",
+					Schema:       `[\"akc.test.userAdded\"]`,
+					Subject:      fmt.Sprintf("sub%s", u),
+				},
+				References: []Reference{
+					{
+						Name:    "akc.test.userAdded",
+						Subject: "schemaregistry_schema.referencedSchema.subject",
+						Version: "schemaregistry_schema.referencedSchema.version",
+					},
+				},
+			},
+			check: []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr("schemaregistry_schema.referencedSchema", "id", fmt.Sprintf("referencedSub-%s", u)),
+				resource.TestCheckResourceAttr("schemaregistry_schema.referencedSchema", "subject", fmt.Sprintf("referencedSub-%s", u)),
+				resource.TestCheckResourceAttrSet("schemaregistry_schema.referencedSchema", "schema_id"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.referencedSchema", "version", "1"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.referencedSchema", "schema", strings.Replace(fixtureAvro1, "\\", "", -1)),
+
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "id", fmt.Sprintf("sub%s", u)),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "subject", fmt.Sprintf("sub%s", u)),
+				resource.TestCheckResourceAttrSet("schemaregistry_schema.schemaWithReference", "schema_id"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "version", "1"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "schema", strings.Replace(`[\"akc.test.userAdded\"]`, "\\", "", -1)),
+
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.#", "1"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.name", "akc.test.userAdded"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.subject", fmt.Sprintf("referencedSub-%s", u)),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.version", "1"),
+			},
+		},
+		{
+			name: "multiple references",
+			fixture: schemaWithReferenceFixture{
+				Referenced: []SchemaResource{
+					{
+						ResourceName: "referencedSchema",
+						Schema:       fixtureAvro1,
+						Subject:      fmt.Sprintf("referencedSub-%s", u),
+					},
+					{
+						ResourceName: "otherReferencedSchema",
+						Schema:       `{\"type\":\"record\",\"name\":\"other\",\"namespace\":\"foo.bar\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}`,
+						Subject:      fmt.Sprintf("otherReferencedSub-%s", u),
+					},
+				},
+				WithReferences: SchemaResource{
+					ResourceName: "schemaWithReference",
+					Schema:       `[\"akc.test.userAdded\"]`,
+					Subject:      fmt.Sprintf("sub%s", u),
+				},
+				References: []Reference{
+					{
+						Name:    "akc.test.userAdded",
+						Subject: "schemaregistry_schema.referencedSchema.subject",
+						Version: "schemaregistry_schema.referencedSchema.version",
+					},
+					{
+						Name:    "foo.bar.other",
+						Subject: "schemaregistry_schema.otherReferencedSchema.subject",
+						Version: "schemaregistry_schema.otherReferencedSchema.version",
+					},
+				},
+			},
+			check: []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr("schemaregistry_schema.referencedSchema", "id", fmt.Sprintf("referencedSub-%s", u)),
+				resource.TestCheckResourceAttr("schemaregistry_schema.referencedSchema", "subject", fmt.Sprintf("referencedSub-%s", u)),
+				resource.TestCheckResourceAttrSet("schemaregistry_schema.referencedSchema", "schema_id"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.referencedSchema", "version", "1"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.referencedSchema", "schema", strings.Replace(fixtureAvro1, "\\", "", -1)),
+
+				resource.TestCheckResourceAttr("schemaregistry_schema.otherReferencedSchema", "id", fmt.Sprintf("otherReferencedSub-%s", u)),
+				resource.TestCheckResourceAttr("schemaregistry_schema.otherReferencedSchema", "subject", fmt.Sprintf("otherReferencedSub-%s", u)),
+				resource.TestCheckResourceAttrSet("schemaregistry_schema.otherReferencedSchema", "schema_id"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.otherReferencedSchema", "version", "1"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.otherReferencedSchema", "schema", strings.Replace(`{\"type\":\"record\",\"name\":\"other\",\"namespace\":\"foo.bar\",\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}`, "\\", "", -1)),
+
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "id", fmt.Sprintf("sub%s", u)),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "subject", fmt.Sprintf("sub%s", u)),
+				resource.TestCheckResourceAttrSet("schemaregistry_schema.schemaWithReference", "schema_id"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "version", "1"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "schema", strings.Replace(`[\"akc.test.userAdded\"]`, "\\", "", -1)),
+
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.#", "2"),
+
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.name", "akc.test.userAdded"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.subject", fmt.Sprintf("referencedSub-%s", u)),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.version", "1"),
+
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.1.name", "foo.bar.other"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.1.subject", fmt.Sprintf("otherReferencedSub-%s", u)),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.1.version", "1"),
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+
+			config := fixtureResourceSchemaWithReferenceBuild(tc.fixture)
+			resource.Test(t, resource.TestCase{
+				ProviderFactories: testAccProviders,
+				PreCheck:          func() { testAccPreCheck(t) },
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check: resource.ComposeTestCheckFunc(tc.check...),
+					},
+				},
+			})
+
+		})
+	}
+}
+
+func TestAccResourceSchemaReferences_validateSchema(t *testing.T) {
+	u, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	referencedSubject := fmt.Sprintf("referencedSub-%s", u)
+	schemaWithReferenceSubject := fmt.Sprintf("sub-%s", u)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fixtureResourceSchemaWithReferenceBuild(schemaWithReferenceFixture{
+					Referenced: []SchemaResource{
+						{
+							ResourceName: "referencedSchema",
+							Schema:       fixtureAvro1,
+							Subject:      referencedSubject,
+						},
+					},
+					WithReferences: SchemaResource{
+						ResourceName: "schemaWithReference",
+						Schema:       `[\"invalid.schema\"]`,
+						Subject:      schemaWithReferenceSubject,
+					},
+					References: []Reference{
+						{
+							Name:    "akc.test.userAdded",
+							Subject: "schemaregistry_schema.referencedSchema.subject",
+							Version: "schemaregistry_schema.referencedSchema.version",
+						},
+					},
+				}),
+				ExpectError: regexp.MustCompile(regexp.QuoteMeta(`Invalid schema ["invalid.schema"] with refs`)),
+			},
+		},
+	})
+}
+
+func TestAccResourceSchemaReferences_updateCompatible(t *testing.T) {
+	u, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	referencedSubject := fmt.Sprintf("referencedSub-%s", u)
+	schemaWithReferenceSubject := fmt.Sprintf("sub-%s", u)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fixtureResourceSchemaWithReferenceBuild(schemaWithReferenceFixture{
+					Referenced: []SchemaResource{
+						{
+							ResourceName: "referencedSchema",
+							Schema:       fixtureAvro1,
+							Subject:      referencedSubject,
+						},
+					},
+					WithReferences: SchemaResource{
+						ResourceName: "schemaWithReference",
+						Schema:       `[\"akc.test.userAdded\"]`,
+						Subject:      schemaWithReferenceSubject,
+					},
+					References: []Reference{
+						{
+							Name:    "akc.test.userAdded",
+							Subject: "schemaregistry_schema.referencedSchema.subject",
+							Version: "schemaregistry_schema.referencedSchema.version",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("schemaregistry_schema.referencedSchema", "id", referencedSubject),
+					resource.TestCheckResourceAttr("schemaregistry_schema.referencedSchema", "version", "1"),
+
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "id", schemaWithReferenceSubject),
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "version", "1"),
+
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.#", "1"),
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.version", "1"),
+				),
+			},
+			{
+				Config: fixtureResourceSchemaWithReferenceBuild(schemaWithReferenceFixture{
+					Referenced: []SchemaResource{
+						{
+							ResourceName: "referencedSchema",
+							Schema:       fixtureAvro2,
+							Subject:      referencedSubject,
+						},
+					},
+					WithReferences: SchemaResource{
+						ResourceName: "schemaWithReference",
+						Schema:       `[\"akc.test.userAdded\"]`,
+						Subject:      schemaWithReferenceSubject,
+					},
+					References: []Reference{
+						{
+							Name:    "akc.test.userAdded",
+							Subject: "schemaregistry_schema.referencedSchema.subject",
+							Version: "schemaregistry_schema.referencedSchema.version",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("schemaregistry_schema.referencedSchema", "id", referencedSubject),
+					resource.TestCheckResourceAttr("schemaregistry_schema.referencedSchema", "version", "2"),
+
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "id", schemaWithReferenceSubject),
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "version", "2"),
+
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.#", "1"),
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.version", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceSchemaReferences_updateIncompatible(t *testing.T) {
+	u, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	referencedSubject := fmt.Sprintf("referencedSub-%s", u)
+	schemaWithReferenceSubject := fmt.Sprintf("sub-%s", u)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fixtureResourceSchemaWithReferenceBuild(schemaWithReferenceFixture{
+					Referenced: []SchemaResource{
+						{
+							ResourceName: "referencedSchema",
+							Schema:       fixtureAvro1,
+							Subject:      referencedSubject,
+						},
+					},
+					WithReferences: SchemaResource{
+						ResourceName: "schemaWithReference",
+						Schema:       `[\"akc.test.userAdded\"]`,
+						Subject:      schemaWithReferenceSubject,
+					},
+					References: []Reference{
+						{
+							Name:    "akc.test.userAdded",
+							Subject: "schemaregistry_schema.referencedSchema.subject",
+							Version: "schemaregistry_schema.referencedSchema.version",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("schemaregistry_schema.referencedSchema", "id", referencedSubject),
+					resource.TestCheckResourceAttr("schemaregistry_schema.referencedSchema", "version", "1"),
+
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "id", schemaWithReferenceSubject),
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "version", "1"),
+
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.#", "1"),
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.version", "1"),
+				),
+			},
+			{
+				Config: fixtureResourceSchemaWithReferenceBuild(schemaWithReferenceFixture{
+					Referenced: []SchemaResource{
+						{
+							ResourceName: "referencedSchema",
+							Schema:       fixtureAvro1,
+							Subject:      referencedSubject,
+						},
+					},
+					WithReferences: SchemaResource{
+						ResourceName: "schemaWithReference",
+						Schema:       `[\"akc.test.incompatible\"]`,
+						Subject:      schemaWithReferenceSubject,
+					},
+					References: []Reference{
+						{
+							Name:    "akc.test.userAdded",
+							Subject: "schemaregistry_schema.referencedSchema.subject",
+							Version: "schemaregistry_schema.referencedSchema.version",
+						},
+					},
+				}),
+				ExpectError: regexp.MustCompile(regexp.QuoteMeta(`Invalid schema ["akc.test.incompatible"] with refs`)),
+			},
+		},
+	})
+}
+
+func TestAccResourceSchemaReferences_import(t *testing.T) {
+	u, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	referencedSubject := fmt.Sprintf("referencedSub-%s", u)
+	schemaWithReferenceSubject := fmt.Sprintf("sub-%s", u)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fixtureResourceSchemaWithReferenceBuild(schemaWithReferenceFixture{
+					Referenced: []SchemaResource{
+						{
+							ResourceName: "referencedSchema",
+							Schema:       fixtureAvro1,
+							Subject:      referencedSubject,
+						},
+					},
+					WithReferences: SchemaResource{
+						ResourceName: "schemaWithReference",
+						Schema:       `[\"akc.test.userAdded\"]`,
+						Subject:      schemaWithReferenceSubject,
+					},
+					References: []Reference{
+						{
+							Name:    "akc.test.userAdded",
+							Subject: "schemaregistry_schema.referencedSchema.subject",
+							Version: "schemaregistry_schema.referencedSchema.version",
+						},
+					},
+				}),
+			},
+			{
+				ResourceName:      "schemaregistry_schema.referencedSchema",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "schemaregistry_schema.schemaWithReference",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func RequiresImportError(resourceName string) *regexp.Regexp {
 	message := "to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for %q for more information."
 	return regexp.MustCompile(fmt.Sprintf(message, resourceName))

--- a/schemaregistry/resource_schema_test.go
+++ b/schemaregistry/resource_schema_test.go
@@ -168,10 +168,10 @@ func TestAccResourceSchemaReferences_basic(t *testing.T) {
 				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "version", "1"),
 				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "schema", strings.Replace(`[\"akc.test.userAdded\"]`, "\\", "", -1)),
 
-				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.#", "1"),
-				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.name", "akc.test.userAdded"),
-				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.subject", fmt.Sprintf("referencedSub-%s", u)),
-				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.version", "1"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.#", "1"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.0.name", "akc.test.userAdded"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.0.subject", fmt.Sprintf("referencedSub-%s", u)),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.0.version", "1"),
 			},
 		},
 		{
@@ -226,15 +226,15 @@ func TestAccResourceSchemaReferences_basic(t *testing.T) {
 				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "version", "1"),
 				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "schema", strings.Replace(`[\"akc.test.userAdded\"]`, "\\", "", -1)),
 
-				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.#", "2"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.#", "2"),
 
-				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.name", "akc.test.userAdded"),
-				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.subject", fmt.Sprintf("referencedSub-%s", u)),
-				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.version", "1"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.0.name", "akc.test.userAdded"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.0.subject", fmt.Sprintf("referencedSub-%s", u)),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.0.version", "1"),
 
-				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.1.name", "foo.bar.other"),
-				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.1.subject", fmt.Sprintf("otherReferencedSub-%s", u)),
-				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.1.version", "1"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.1.name", "foo.bar.other"),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.1.subject", fmt.Sprintf("otherReferencedSub-%s", u)),
+				resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.1.version", "1"),
 			},
 		},
 	}
@@ -341,8 +341,8 @@ func TestAccResourceSchemaReferences_updateCompatible(t *testing.T) {
 					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "id", schemaWithReferenceSubject),
 					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "version", "1"),
 
-					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.#", "1"),
-					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.version", "1"),
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.#", "1"),
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.0.version", "1"),
 				),
 			},
 			{
@@ -374,8 +374,8 @@ func TestAccResourceSchemaReferences_updateCompatible(t *testing.T) {
 					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "id", schemaWithReferenceSubject),
 					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "version", "2"),
 
-					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.#", "1"),
-					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.version", "2"),
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.#", "1"),
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.0.version", "2"),
 				),
 			},
 		},
@@ -424,8 +424,8 @@ func TestAccResourceSchemaReferences_updateIncompatible(t *testing.T) {
 					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "id", schemaWithReferenceSubject),
 					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "version", "1"),
 
-					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.#", "1"),
-					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "references.0.version", "1"),
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.#", "1"),
+					resource.TestCheckResourceAttr("schemaregistry_schema.schemaWithReference", "reference.0.version", "1"),
 				),
 			},
 			{


### PR DESCRIPTION
## Why do we need this

see #13 

I tried to respect the existing codebase: reuse the same test cases, variable naming, ...
This PR is pretty big, but it's mostly tests and documentation, could not find a way to split it.
I can rework it if you think of something.

> Given the schema `a` is updated, the schema `b` version should be updated and its reference to schema `a` version also.
> If one wants to stick with a version he can just hardcode it in the reference block

Manually sticking a version is actually harder than expected and is not covered (more on this below).
In that PR, I propose to always update a reference version to the latest referenced schema's one.

## What changed

- **DataSource** with schema references support & tests: 
  - `references` exposed as `output` value
  - In the reference test setup, create in test setup a referenced schema and a schema with reference using the registry client
  - Update  [riferrei/srclient](https://github.com/riferrei/srclient) dependency from `0.3.0` to `0.3.1` to fetch `references` from schema registry

- **Resource** with schema references support & tests: 
  - CRU operations handling `references`
  - Introduce `CustomizeDiff` schema function to explicitly set a version change on schema change and make dependencies aware of a version changed at `plan` time (computed field)
  - Fixture text templates as schemas with references are complex to handle with simple string format
- **Examples** and **readme** updated: 
  - Update the `main.tf` required provider version to `0.6`

## Sticking a reference to a specific version

This is my first terraform dev, but as I understand it, referencing a referenced resource schema in a given version while updating this referenced schema to a new version would require duplicating the resource, something like:

```
resource "schemaregistry_schema" "user_added_latest" {
  subject = "MyTopic-akc.test.userAdded-value"
  schema  = file("./userAdded_v2.avsc")
}

resource "schemaregistry_schema" "user_added_v1" {
  subject = "MyTopic-akc.test.userAdded-value"
  schema  = file("./userAdded.avsc")
}

resource "schemaregistry_schema" "with_reference" {
  subject = "with-reference"
  schema = "[\"akc.test.userAdded\"]"
  references {
    name = "akc.test.userAdded"
    subject = schemaregistry_schema.user_added_v1.subject
    version = 1
  }
} 
```

This is not possible with current implementation as the schema `subject` is used as a terraform schema `ID`.
One way I see could be to rely on schema id instead but that would introduce too many changes for that PR.

## Notes

- locally tested `terraform plan` & `apply`
- relied on the docker containers:
  - broker: `confluentinc/cp-server:6.1.1`
  - schema-registry: `confluentinc/cp-schema-registry:6.1.1`
  - zookeeper: `confluentinc/cp-zookeeper:6.1.1`