### PR TITLE
DataSource with optional version support, latest by default

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -31,6 +31,12 @@ data "schemaregistry_schema" "main" {
   subject = schemaregistry_schema.with_reference.subject
 }
 
+data "schemaregistry_schema" "user_added_v1" {
+  subject = "MyTopic-akc.test.userAdded-value"
+  schema  = 1
+}
+
+
 output "schema_id" {
   value = data.schemaregistry_schema.main.id
 }

--- a/schemaregistry/data_source_schema.go
+++ b/schemaregistry/data_source_schema.go
@@ -19,7 +19,7 @@ func dataSourceSchema() *schema.Resource {
 			},
 			"version": {
 				Type:        schema.TypeInt,
-				Computed:    true,
+				Optional:    true,
 				Description: "The version of the schema",
 			},
 			"schema_id": {
@@ -64,13 +64,21 @@ func dataSourceSubjectRead(ctx context.Context, d *schema.ResourceData, m interf
 	var diags diag.Diagnostics
 
 	subject := d.Get("subject").(string)
+	version := d.Get("version").(int)
 
 	client := m.(*srclient.SchemaRegistryClient)
+	var schema *srclient.Schema
+	var err error
 
-	schema, err := client.GetLatestSchemaWithArbitrarySubject(subject)
+	if version > 0 {
+		schema, err = client.GetSchemaByVersionWithArbitrarySubject(subject, version)
+
+	} else {
+		schema, err = client.GetLatestSchemaWithArbitrarySubject(subject)
+	}
+
 	if err != nil {
 		return diag.FromErr(err)
-		// return diag.FromErr(fmt.Errorf("unknown schema for subject '%s'", subject))
 	}
 
 	d.Set("schema", schema.Schema())


### PR DESCRIPTION
see #15

**What changed**

- dataSource `version` field from `computed` to `optional`
- load a specific version when that field is set, else keep existing logic (fetch `latest`)
- Readme

**Usage**
1. Declare an event schema and a topic's one with reference as usual
```
resource "schemaregistry_schema" "user_added" {
  subject = "MyTopic-akc.test.userAdded-value"
  schema  = file("./userAdded.avsc")
}

resource "schemaregistry_schema" "with_reference" {
  subject = "with-reference"
  schema = "[\"akc.test.userAdded\"]"

  reference {
    name = "akc.test.userAdded"
    subject = schemaregistry_schema.user_added.subject
    version = schemaregistry_schema.user_added.version
  }
}
```

2. Event schema evolves, topic now refers to v1 event schema with dataSource
```
resource "schemaregistry_schema" "user_added" {
  subject = "MyTopic-akc.test.userAdded-value"
  schema  = file("./userAdded_v2.avsc")
}

data "schemaregistry_schema" "user_added_v1" {
  subject = "MyTopic-akc.test.userAdded-value"
  version = 1
}

resource "schemaregistry_schema" "with_reference" {
  subject = "with-reference"
  schema = "[\"akc.test.userAdded\"]"

  reference {
    name = "akc.test.userAdded"
    subject = data.schemaregistry_schema.user_added_v1.subject
    version = data.schemaregistry_schema.user_added_v1.version
  }
}
```